### PR TITLE
Join the fields array to a comma-delimited string

### DIFF
--- a/facebook.js
+++ b/facebook.js
@@ -100,7 +100,7 @@ function getIdentity(accessToken, fields) {
     return HTTP.get("https://graph.facebook.com/v2.4/me", {
       params: {
         access_token: accessToken,
-        fields: fields
+        fields: fields.join(",")
       }
     }).data;
   } catch (err) {


### PR DESCRIPTION
the `fields` at the `getIdentity(...)` GET Request needs to be a comma-delimited string according to the Graph API:
https://developers.facebook.com/docs/graph-api/using-graph-api/

this fixes Internal server error [500] on `Meteor.call("login", { facebookAccessToken: ...});` 